### PR TITLE
Separate sending request logic.

### DIFF
--- a/Callable.xcodeproj/project.pbxproj
+++ b/Callable.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		169C17A5209945BC008A94D2 /* CallableSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169C17A4209945BC008A94D2 /* CallableSession.swift */; };
+		169C17A6209947F5008A94D2 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169C17A2209945B0008A94D2 /* Session.swift */; };
+		169C17A720994B9F008A94D2 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169C17A2209945B0008A94D2 /* Session.swift */; };
+		169C17A820994BAA008A94D2 /* CallableSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169C17A4209945BC008A94D2 /* CallableSession.swift */; };
 		320D9A5720651B6B00BF5396 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320D9A5620651B6B00BF5396 /* AppDelegate.swift */; };
 		320D9A5920651B6B00BF5396 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320D9A5820651B6B00BF5396 /* ViewController.swift */; };
 		320D9A5C20651B6B00BF5396 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 320D9A5A20651B6B00BF5396 /* Main.storyboard */; };
@@ -33,6 +37,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		169C17A2209945B0008A94D2 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		169C17A4209945BC008A94D2 /* CallableSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallableSession.swift; sourceTree = "<group>"; };
 		1D0803CA92EFDB6C97F9ED65 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		320D9A5420651B6B00BF5396 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		320D9A5620651B6B00BF5396 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -128,6 +134,8 @@
 				32F355572065143500E49EF2 /* Callable.h */,
 				32F355582065143500E49EF2 /* Info.plist */,
 				32F3556E2065144600E49EF2 /* Callable.swift */,
+				169C17A2209945B0008A94D2 /* Session.swift */,
+				169C17A4209945BC008A94D2 /* CallableSession.swift */,
 			);
 			path = Callable;
 			sourceTree = "<group>";
@@ -466,8 +474,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				169C17A720994B9F008A94D2 /* Session.swift in Sources */,
 				320D9A5920651B6B00BF5396 /* ViewController.swift in Sources */,
 				320D9A5720651B6B00BF5396 /* AppDelegate.swift in Sources */,
+				169C17A820994BAA008A94D2 /* CallableSession.swift in Sources */,
 				320D9A6620651B8000BF5396 /* Callable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -476,7 +486,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				169C17A5209945BC008A94D2 /* CallableSession.swift in Sources */,
 				32F3556F2065144600E49EF2 /* Callable.swift in Sources */,
+				169C17A6209947F5008A94D2 /* Session.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Callable.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Callable.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Callable/CallableSession.swift
+++ b/Callable/CallableSession.swift
@@ -1,0 +1,33 @@
+//
+//  CallableSessionAdapter.swift
+//  Callable
+//
+//  Created by suguru-kishimoto on 2018/05/02.
+//  Copyright © 2018年 star__hoshi. All rights reserved.
+//
+
+import Foundation
+import FirebaseFunctions
+
+public class CallableSession: Session {
+    public static let shared = CallableSession()
+
+    private init() {
+    }
+
+    public func send(_ path: String, parameter: [String : Any]?, handler: @escaping (Data?, Error?) -> Void) {
+        Functions.functions().httpsCallable(path)
+            .call(parameter) { result, error in
+                if let result = result {
+                    do {
+                        let data = try JSONSerialization.data(withJSONObject: result.data, options: [])
+                        handler(data, error)
+                    } catch let error {
+                        handler(nil, error)
+                    }
+                } else {
+                    handler(nil, error)
+                }
+        }
+    }
+}

--- a/Callable/Session.swift
+++ b/Callable/Session.swift
@@ -1,0 +1,13 @@
+//
+//  SessionAdapter.swift
+//  Callable
+//
+//  Created by suguru-kishimoto on 2018/05/02.
+//  Copyright © 2018年 star__hoshi. All rights reserved.
+//
+
+import Foundation
+
+public protocol Session {
+    func send(_ path: String, parameter: [String: Any]?, handler: @escaping (Data?, Error?) -> Void)
+}

--- a/CallableTests/CallableTests.swift
+++ b/CallableTests/CallableTests.swift
@@ -9,28 +9,61 @@
 import XCTest
 @testable import Callable
 
+private func makeCallableError(details: [String: Any] = [:], code: Int = 0, description: String = "") -> NSError {
+    return NSError(
+        domain: "com.firebase.functions",
+        code: code,
+        userInfo: ["details": details, NSLocalizedDescriptionKey: description])
+}
+
 class CallableTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    class MockSession: Session {
+        let data: Data?
+        let error: Error?
+        init(data: Data? = nil, error: Error? = nil) {
+            self.data = data
+            self.error = error
+        }
+
+        func send(_ path: String, parameter: [String : Any]?, handler: @escaping (Data?, Error?) -> Void) {
+            handler(data, error)
         }
     }
-    
+
+    struct TestRequest: Callable {
+        struct Response: Decodable {
+            let name: String
+        }
+        let path: String = "httpcallabletest"
+    }
+
+    func testSuccessMockSession() {
+        let json = try! JSONSerialization.data(withJSONObject: ["name": "Mike"], options: [])
+        let expectation = XCTestExpectation()
+        TestRequest().call(MockSession(data: json)) { result in
+            XCTAssertNotNil(result.value)
+            XCTAssertNil(result.error)
+            XCTAssertEqual(result.value?.name, "Mike")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testFailureMockSession() {
+        let error = makeCallableError(details: ["code": "foobar"])
+        let expectation = XCTestExpectation()
+        TestRequest().call(MockSession(error: error)) { result in
+            XCTAssertNotNil(result.error)
+            XCTAssertNil(result.value)
+            if let error = result.error, case let CallableError.function(functionError as NSError) = error {
+                XCTAssertNotNil(functionError.userInfo)
+                XCTAssertNotNil(functionError.userInfo["details"] as? [String: Any])
+                XCTAssertEqual((functionError.userInfo["details"] as? [String: Any])?["code"] as? String, "foobar")
+            } else {
+                XCTFail()
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
 }


### PR DESCRIPTION
I just implemented `Session` protocol.

By replacing `Session`, we can test using mock.


```swift
    class MockSession: Session {
        let data: Data?
        let error: Error?
        init(data: Data? = nil, error: Error? = nil) {
            self.data = data
            self.error = error
        }

        func send(_ path: String, parameter: [String : Any]?, handler: @escaping (Data?, Error?) -> Void) {
            handler(data, error)
        }
    }

    struct TestRequest: Callable {
        struct Response: Decodable {
            let name: String
        }
        let path: String = "httpcallabletest"
    }
```

```swift
    func test() {
        let json = try! JSONSerialization.data(withJSONObject: ["name": "Mike"], options: [])
        let expectation = XCTestExpectation()
        TestRequest().call(MockSession(data: json)) { result in
            XCTAssertNotNil(result.value)
            XCTAssertNil(result.error)
            XCTAssertEqual(result.value?.name, "Mike")
            expectation.fulfill()
        }
        wait(for: [expectation], timeout: 1.0)
    }
```